### PR TITLE
fixes renderflow exception on multiple screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -562,13 +562,12 @@ class CarryOutScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: Scaffold(
+    return Scaffold(
         appBar: AppBar(
           elevation: 0.0,
           backgroundColor: Colors.transparent,
         ),
-        body: Padding(
+        body: SingleChildScrollView(
           padding: const EdgeInsets.fromLTRB(30.0, 0.0, 30.0, 0.0),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
@@ -673,8 +672,7 @@ class CarryOutScreen extends StatelessWidget {
             ],
           ),
         ),
-      ),
-    );
+      );
   }
 }
 
@@ -758,10 +756,12 @@ class BookShelf extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return Expanded(
+      child:Column(
       children: <Widget>[
         InkWell(
           child: Column(
+            mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               Container(
                 width: 110.0,
@@ -791,6 +791,7 @@ class BookShelf extends StatelessWidget {
           ),
         ),
       ],
+      )
     );
   }
 }

--- a/lib/tab_1.dart
+++ b/lib/tab_1.dart
@@ -115,8 +115,9 @@ class TabOneScreen extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.only(top: 20.0, bottom: 10.0),
                     child: Row(
+                      mainAxisSize: MainAxisSize.min,
                       children: <Widget>[
-                        InkWell(
+                        Expanded(
                           child: Container(
                             width: 160.0,
                             height: 240.0,
@@ -254,11 +255,11 @@ class TabOneScreen extends StatelessWidget {
                                     children: <Widget>[
                                       Padding(
                                         padding:
-                                            const EdgeInsets.only(right: 10.0),
+                                            const EdgeInsets.only(right: 5.0),
                                         child: InkWell(
                                           child: Container(
                                             padding: const EdgeInsets.symmetric(
-                                                horizontal: 10.0,
+                                                horizontal: 5.0,
                                                 vertical: 6.0),
                                             decoration: BoxDecoration(
                                               border: Border.all(
@@ -284,7 +285,7 @@ class TabOneScreen extends StatelessWidget {
                                         child: InkWell(
                                           child: Container(
                                             padding: const EdgeInsets.symmetric(
-                                                horizontal: 10.0,
+                                                horizontal: 8.0,
                                                 vertical: 6.0),
                                             decoration: BoxDecoration(
                                               border: Border.all(

--- a/lib/tab_2.dart
+++ b/lib/tab_2.dart
@@ -139,9 +139,7 @@ class MayLikeBooks extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 5.0, horizontal: 20.0),
-      child: Container(
+    return Container(
         height: 140.0,
         decoration: BoxDecoration(
           color: Colors.white,
@@ -173,8 +171,10 @@ class MayLikeBooks extends StatelessWidget {
                 width: 10.0,
               ),
               Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.end,
+                mainAxisSize: MainAxisSize.min,
+              //  mainAxisAlignment: MainAxisAlignment.center,
+              //  crossAxisAlignment: CrossAxisAlignment.start,
+              //  mainAxisAlignment: MainAxisAlignment.end,
                 children: <Widget>[
                   Text(
                     bookName,
@@ -234,8 +234,7 @@ class MayLikeBooks extends StatelessWidget {
             ],
           ),
         ),
-      ),
-    );
+      );
   }
 }
 


### PR DESCRIPTION
This PR fixes multiple renderflow exception occuring on both platforms, and also fixes [this](https://github.com/serdarpolat/flutter_book_reader_app_ui/issues/1) issue.

**Before:**

![screen shot 2019-01-29 at 11 14 11 am](https://user-images.githubusercontent.com/16548367/52175227-b4b0bc00-27c6-11e9-87e0-f24fdb186e61.png)
![screen shot 2019-01-29 at 11 14 27 am](https://user-images.githubusercontent.com/16548367/52175228-b5495280-27c6-11e9-8b03-9e82b61690fe.png)
![screen shot 2019-02-03 at 3 09 23 pm](https://user-images.githubusercontent.com/16548367/52175229-b5e1e900-27c6-11e9-9fad-f2c33ce0b6d9.png)

**After:**

![screen shot 2019-02-03 at 3 09 53 pm](https://user-images.githubusercontent.com/16548367/52175250-e4f85a80-27c6-11e9-99b6-33c123a741c6.png)
![screen shot 2019-02-03 at 3 10 03 pm](https://user-images.githubusercontent.com/16548367/52175252-e590f100-27c6-11e9-8199-2e99ac9b037e.png)
![screen shot 2019-02-03 at 3 10 17 pm](https://user-images.githubusercontent.com/16548367/52175253-e6298780-27c6-11e9-89ae-d027be547e31.png)
